### PR TITLE
Correct horizontal_rule, add old implementation to header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,22 @@ Header
 ------
 
 Return a header of specified level.
+
+Keyword arguments:
+    style -- Specifies the header style (default atx). The "atx" style uses
+    hash signs, and has 6 levels. The "setext" style uses dashes or equals
+    signs for headers of levels 1 and 2 respectively, and is limited to
+    those two levels.
+
+Specifying a level outside of the style's range results in a ValueError.
 ::
 
     >>> header("Main Title", 1)
     '# Main Title'
     >>> header("Smaller subtitle", 4)
     '#### Smaller subtitle'
+    >>> header("Setext style", 2)
+    'Setext style\n---'
 
 
 Italics
@@ -137,10 +147,20 @@ Horizontal rule
 ---------------
 
 Return a horizontal rule.
+
+Keyword arguments:
+    length -- Specifies the length of the rule (default 79, minimum 3).
+
+    style -- Character used for the rule (may be either "_" or "*").
+
+If the length is too low, or the style is invalid, a ValueError is raised.
 ::
 
     >>> horizontal_rule()
-    '-------------------------------------------------------------------------------'
+    '_______________________________________________________________________________'
+    >>> horizontal_rule(length=5, style="*")
+    '***'
+    """
 
 
 Non-standard markdown

--- a/markdown_strings/__init__.py
+++ b/markdown_strings/__init__.py
@@ -36,15 +36,34 @@ def esc_format(text):
 # Emphasis
 
 
-def header(heading_text, header_level):
+def header(heading_text, header_level, style="atx"):
     """Return a header of specified level.
+    The "atx" style uses hash signs, and has 6 levels.
+    The "setext" style uses dashes or equals signs for headers of level
+    1 and 2 respectively, and is limited to those two levels.
+
+    Specifying a level outside of the style's range results in a ValueError.
 
     >>> header("Main Title", 1)
     '# Main Title'
     >>> header("Smaller subtitle", 4)
     '#### Smaller subtitle'
+    >>> header("Setext style", 2)
+    'Setext style\n---'
     """
-    return(("#" * header_level) + " " + esc_format(heading_text))
+    if type(header_level) != int:
+        raise TypeError("header_level must be int")
+    if style not in ["atx", "setext"]:
+        raise ValueError("Invalid style %s (choose 'atx' or 'setext')" % style)
+    if style == "atx":
+        if not 1 <= header_level <= 6:
+            raise ValueError("Invalid level %d for atx" % header_level)
+        return(("#" * header_level) + " " + esc_format(heading_text))
+    else:
+        if not 0 < header_level < 3:
+            raise ValueError("Invalid level %d for setext" % header_level)
+        ch = "=" if header_level == 1 else "-"
+        return esc_format(heading_text) + ("\n%s" % (ch * 3))
 
 
 def italics(text):
@@ -172,13 +191,22 @@ def blockquote(text):
     return("\n".join(["> " + esc_format(item) for item in text.split("\n")]))
 
 
-def horizontal_rule():
-    """Return a horizontal rule.
+def horizontal_rule(length=79, style="_"):
+    """Return a horizontal rule of given length (default 79, minimum 3).
+    style may be either "_" or "*".
+
+    If the length is too low, or the style is invalid, a ValueError is raised.
 
     >>> horizontal_rule()
-    '-------------------------------------------------------------------------------'
+    '_______________________________________________________________________________'
+    >>> horizontal_rule(length=5, style="*")
+    '***'
     """
-    return("-" * 79)
+    if style not in ["_", "*"]:
+        raise ValueError("Invalid style (choose '_' or '*')")
+    if length < 3:
+        raise ValueError("length must be >= 3")
+    return(style * length)
 
 
 # Non-standard markdown

--- a/markdown_strings/__init__.py
+++ b/markdown_strings/__init__.py
@@ -38,9 +38,12 @@ def esc_format(text):
 
 def header(heading_text, header_level, style="atx"):
     """Return a header of specified level.
-    The "atx" style uses hash signs, and has 6 levels.
-    The "setext" style uses dashes or equals signs for headers of level
-    1 and 2 respectively, and is limited to those two levels.
+
+    Keyword arguments:
+        style -- Specifies the header style (default atx).
+            The "atx" style uses hash signs, and has 6 levels.
+            The "setext" style uses dashes or equals signs for headers of
+            levels 1 and 2 respectively, and is limited to those two levels.
 
     Specifying a level outside of the style's range results in a ValueError.
 
@@ -192,8 +195,11 @@ def blockquote(text):
 
 
 def horizontal_rule(length=79, style="_"):
-    """Return a horizontal rule of given length (default 79, minimum 3).
-    style may be either "_" or "*".
+    """Return a horizontal rule.
+
+    Keyword arguments:
+        length -- Specifies the length of the rule (default 79, minimum 3).
+        style -- Character used for the rule (may be either "_" or "*").
 
     If the length is too low, or the style is invalid, a ValueError is raised.
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as file:
 
 setup(
      name='markdown_strings',
-     version='2.1.3',
+     version='3.0.0',
      description='Create markdown formatted text',
      long_description=long_description,
      url='https://github.com/awesmubarak/markdown_strings',


### PR DESCRIPTION
This is a breaking change, so I'll understand if you don't want to merge.

`horizontal_rule` now follows the [Markdown spec](https://daringfireball.net/projects/markdown/syntax#hr), and its old version is now in `header` as the "setext" style. It also has a `length` option, which closes #2 